### PR TITLE
changes to work with React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
     "lint": "eslint --color src/**/*.js"
   },
   "dependencies": {
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-preset-env": "^1.6.1",
+    "create-react-class": "^15.6.2",
+    "prop-types": "^15.6.0",
     "random-hex": "^1.0.2"
   }
 }

--- a/src/components/Canvas.jsx
+++ b/src/components/Canvas.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { generateParticles, updateParticles } from '../utils/particle';
+import { PropTypes } from 'prop-types';
+import { createReactClass } from 'create-react-class';
 
-const PropTypes = React.PropTypes;
 
 const PROFILE = [ 'snow', 'steady' ];
 const AMOUNT = 800;


### PR DESCRIPTION
I really like this package, so this is just a quick fix to get it up and running with react 16:

- added 'babel-plugin-transform-decorators-legacy' module to fix "missing" error
- added 'babel-preset-env' module to fix "missing" error
- added 'prop-types' module to support usage in Canvas.jsx
- added 'createReactClass' module to support usage in Canvas.jsx
- modified Canvas.jsx to import 'prop-types' and 'createReactClass'

I'm interested in doing a more complete update that doesn't rely on the the above patches and may do so as I have time.

Thanks!
